### PR TITLE
RF: allow mix of value and percentile vlims

### DIFF
--- a/nibabel/benchmarks/bench_streamlines.py
+++ b/nibabel/benchmarks/bench_streamlines.py
@@ -91,5 +91,6 @@ def bench_load_trk():
         for s1, s2 in zip(scalars_new, scalars_old):
             assert_array_equal(s1, s2)
 
+
 if __name__ == '__main__':
     bench_load_trk()

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -165,6 +165,7 @@ def shared_range(flt_type, int_type):
     _SHARED_RANGES[key] = (mn, mx)
     return mn, mx
 
+
 # ----------------------------------------------------------------------------
 # Routines to work out the next lowest representable integer in floating point
 # types.

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -40,6 +40,7 @@ class ClassMapDict(dict):
     def __getitem__(self, *args, **kwargs):
         return super(ClassMapDict, self).__getitem__(*args, **kwargs)
 
+
 class_map = ClassMapDict(
     analyze={'class': AnalyzeImage,  # Image class
              'ext': '.img',  # characteristic image extension
@@ -94,6 +95,7 @@ class ExtMapRecoder(Recoder):
                             '2.1', '4.0')
     def __getitem__(self, *args, **kwargs):
         return super(ExtMapRecoder, self).__getitem__(*args, **kwargs)
+
 
 # mapping of extensions to default image class names
 ext_map = ExtMapRecoder((

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -671,9 +671,11 @@ class SpatialImage(FileBasedImage):
         axes : tuple of mpl.Axes or None, optional
             3 or 4 axes instances for the 3 slices plus volumes,
             or None (default).
-        vlim : array-like or None, optional
-            Value limits to display image and time series. Can be None
-            (default) to derive limits from data.
+        vlim : None or length 2 sequence, optional
+            Lower, higher value limits to display image and time series. Can be
+            None (default), corresponding to ``('1%', '99%')``. Bounds can be
+            of the form ``x`` where ``x`` is a numerical value, or ``'x%'`` to
+            use the ``x`` percentile of the data.
         slicer : object or None
             Something that can be used to slice an array as in
             ``arr[sliceobj]``. Can be None (default) to display all data.

--- a/nibabel/spm2analyze.py
+++ b/nibabel/spm2analyze.py
@@ -130,5 +130,6 @@ class Spm2AnalyzeImage(spm99.Spm99AnalyzeImage):
     """
     header_class = Spm2AnalyzeHeader
 
+
 load = Spm2AnalyzeImage.load
 save = Spm2AnalyzeImage.instance_to_filename

--- a/nibabel/tests/test_viewers.py
+++ b/nibabel/tests/test_viewers.py
@@ -123,3 +123,24 @@ def test_viewer():
     OrthoSlicer3D(data, slicer=(slice(0, -1), slice(0, -1), slice(0, -1))).close()
     # Fail if we slice too thin
     assert_raises(ValueError, OrthoSlicer3D, data, slicer=(Ellipsis, 0, 0))
+
+
+@needs_mpl
+def test_viewer_vlims():
+    shape = (5, 6, 7)
+    data = np.linspace(-1, 2, np.prod(shape)).reshape(shape)
+    p1, p3, p94, p99 = np.percentile(data, [1, 3, 94, 99])
+    assert_array_equal(OrthoSlicer3D(data).clim, [p1, p99])
+    for vlim, expected in ((None, (p1, p99)),
+                           ((0, 1), (0, 1)),
+                           ((0, '94%'), (0, p94)),
+                           (('3%', 1), (p3, 1)),
+                           (('3%', '94%'), (p3, p94)),
+                          ):
+        assert_array_equal(OrthoSlicer3D(data, vlim=vlim).clim, expected)
+        # Default
+        ov = OrthoSlicer3D(data)
+        assert_array_equal(ov.clim, [p1, p99])
+        # Changed
+        ov.clim = vlim
+        assert_array_equal(ov.clim, expected)


### PR DESCRIPTION
Allow vlimit specifiers to contain mix of percentiles and values.

Use checker to set clims to data, so viewer.clim = ('1%', '99%') will
also work as expected.