### PR TITLE
DOC: Add affiliation and ORCiD id for Jon Haitz Legarreta.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -217,7 +217,9 @@
       "name": "Gonzalez, Ivan"
     },
     {
-      "name": "Legarreta, Jon Haitz"
+      "affiliation": "Universit\u00e9 de Sherbrooke",
+      "name": "Legarreta, Jon Haitz",
+      "orcid": "0000-0002-9661-1396"
     },
     {
       "name": "Lecher, Justin"


### PR DESCRIPTION
Add affiliation and ORCiD id for Jon Haitz Legarreta.